### PR TITLE
Remove promo cards' smaller skill slot limitation.

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -565,13 +565,13 @@ class Idol(ExportModelOperationsMixin('Idol'), models.Model):
 
 admin.site.register(Idol)
 
-# minimum, maximum, promo
+# minimum, maximum
 SKILL_SLOTS_MINMAX = {
-    'N': [0, 1, 0],
-    'R': [1, 2, 1],
-    'SR': [2, 4, 1],
-    'SSR': [3, 6, 2],
-    'UR': [4, 8, 2],
+    'N': [0, 1],
+    'R': [1, 2],
+    'SR': [2, 4],
+    'SSR': [3, 6],
+    'UR': [4, 8],
 }
 
 class Card(ExportModelOperationsMixin('Card'), models.Model):
@@ -650,14 +650,10 @@ class Card(ExportModelOperationsMixin('Card'), models.Model):
 
     @property
     def min_skill_slot(self):
-        if self.is_promo:
-            return SKILL_SLOTS_MINMAX[self.rarity][2]
         return SKILL_SLOTS_MINMAX[self.rarity][0]
 
     @property
     def max_skill_slot(self):
-        if self.is_promo:
-            return SKILL_SLOTS_MINMAX[self.rarity][2]
         return SKILL_SLOTS_MINMAX[self.rarity][1]
 
     @property


### PR DESCRIPTION
Issue #321

All promo cards in EN and JP now have access to the same number of skill slots as normal cards of their rarity.

(I'm pretty sure this change is correct, but I have not been able to test it.  No time to set up a proper test environment.  Sorry.  >.<)

 